### PR TITLE
Feature: Actor Path Editor

### DIFF
--- a/src/extmath.c
+++ b/src/extmath.c
@@ -294,6 +294,57 @@ Vec3f Vec3f_FaceNormalToYawPitch64(Vec3f direction)
 	return angles;
 }
 
+Vec2f Vec2f_GetLineLineIntersection(Vec2f a1, Vec2f a2, Vec2f b1, Vec2f b2)
+{
+	// Calculate the direction vectors of the segments
+	Vec2f r = { a2.x - a1.x, a2.y - a1.y };
+	Vec2f s = { b2.x - b1.x, b2.y - b1.y };
+	Vec2f result = { NAN, NAN };
+	
+	// Calculate the denominator (r.x * s.y - r.y * s.x)
+	float denominator = r.x * s.y - r.y * s.x;
+	
+	// If the denominator is zero, the lines are parallel or collinear
+	if (denominator == 0.0f)
+		return result; // No intersection
+	
+	// Calculate the numerator for the two parameters
+	Vec2f a1b1 = { b1.x - a1.x, b1.y - a1.y };
+	float t = (a1b1.x * s.y - a1b1.y * s.x) / denominator;
+	float u = (a1b1.x * r.y - a1b1.y * r.x) / denominator;
+	
+	// Check if 0 <= t <= 1 and 0 <= u <= 1 for intersection within the segments
+	if (t >= 0.0f && t <= 1.0f && u >= 0.0f && u <= 1.0f)
+	{
+		// Calculate the intersection point
+		result.x = a1.x + t * r.x;
+		result.y = a1.y + t * r.y;
+		return result; // Segments intersect
+	}
+	
+	return result; // No intersection within the segments
+}
+
+Vec2f Vec2f_GetLineRectIntersection(Vec2f a, Vec2f b, Rect rect)
+{
+	Vec2f ul = { rect.x, rect.y };
+	Vec2f ur = { rect.x + rect.w, rect.y };
+	Vec2f ll = { rect.x, rect.y + rect.h };
+	Vec2f lr = { rect.x + rect.w, rect.y + rect.h };
+	Vec2f tmp;
+	
+	if (!isnan((tmp = Vec2f_GetLineLineIntersection(a, b, ul, ur)).x))
+		return tmp;
+	if (!isnan((tmp = Vec2f_GetLineLineIntersection(a, b, ul, ll)).x))
+		return tmp;
+	if (!isnan((tmp = Vec2f_GetLineLineIntersection(a, b, ur, lr)).x))
+		return tmp;
+	if (!isnan((tmp = Vec2f_GetLineLineIntersection(a, b, ll, lr)).x))
+		return tmp;
+	
+	return (Vec2f) { NAN, NAN };
+}
+
 /*
 f32 Math_DelSmoothStepToF(f32* pValue, f32 target, f32 fraction, f32 step, f32 minStep) {
 	step *= gDeltaTime;
@@ -1138,6 +1189,21 @@ Vec4s Vec4s_Median(Vec4s a, Vec4s b) {
 		vec.axis[i] = (a.axis[i] + b.axis[i]) * 0.5f;
 	
 	return vec;
+}
+
+Vec3f Vec3f_LERP(Vec3f a, Vec3f b, float amount)
+{
+	Vec3f vec;
+	
+	for (int i = 0; i < 3; i++)
+		vec.axis[i] = a.axis[i] + (b.axis[i] - a.axis[i]) * amount;
+	
+	return vec;
+}
+
+Vec2f Vec2f_GetLineSlope(Vec2f a, Vec2f b)
+{
+	return Vec2f_New(b.x - a.x, b.y - a.y);
 }
 
 Vec2f Vec2f_Normalize(Vec2f a) {

--- a/src/extmath.h
+++ b/src/extmath.h
@@ -296,6 +296,8 @@ void BoundBox_Adjust3F(BoundBox* bbox, Vec3f point);
 void BoundBox_Adjust2F(BoundBox* bbox, Vec2f point);
 
 bool Vec2f_PointInShape(Vec2f p, Vec2f* poly, u32 numPoly);
+Vec2f Vec2f_GetLineLineIntersection(Vec2f a1, Vec2f a2, Vec2f b1, Vec2f b2);
+Vec2f Vec2f_GetLineRectIntersection(Vec2f a1, Vec2f a2, Rect rect);
 
 Vec3f Vec3f_Cross(Vec3f a, Vec3f b);
 Vec3s Vec3s_Cross(Vec3s a, Vec3s b);
@@ -395,6 +397,10 @@ Vec4f Vec4f_Median(Vec4f a, Vec4f b);
 Vec2s Vec2s_Median(Vec2s a, Vec2s b);
 Vec3s Vec3s_Median(Vec3s a, Vec3s b);
 Vec4s Vec4s_Median(Vec4s a, Vec4s b);
+
+Vec3f Vec3f_LERP(Vec3f a, Vec3f b, float amount);
+
+Vec2f Vec2f_GetLineSlope(Vec2f a, Vec2f b);
 
 Vec2f Vec2f_Normalize(Vec2f a);
 Vec3f Vec3f_Normalize(Vec3f a);

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1589,6 +1589,10 @@ static const LinkedStringFunc *gSidebarTabs[] = {
 				
 				if (ImGui::Button("Set Start Point") && selected != points)
 				{
+					// first and last points are the same
+					if (selectedPath->isClosed)
+						sb_pop(points);
+					
 					// if last point is selected, simply reverse
 					if (selected == &sb_last(points))
 					{
@@ -1599,6 +1603,13 @@ static const LinkedStringFunc *gSidebarTabs[] = {
 						sb_rotate(points, selected - points);
 					}
 					
+					// first and last points are the same
+					if (selectedPath->isClosed)
+					{
+						stb__sbn(points) += 1;
+						sb_last(points).pos = points->pos;
+					}
+					
 					gGui->selectedInstance = points;
 				}
 				ImGui::SameLine();
@@ -1606,6 +1617,32 @@ static const LinkedStringFunc *gSidebarTabs[] = {
 					"Reorders path points such that the currently selected\n"
 					"point will be the first point on the path."
 				);
+				
+				if (sb_count(points) > 3)
+				{
+					ImGui::Checkbox("Is Closed", &selectedPath->isClosed);
+					ImGui::SameLine();
+					HelpMarker(
+						"Indicates a looping path, e.g. the first and\n"
+						"last points are welded together and move as one."
+					);
+					
+					if (selectedPath->isClosed)
+					{
+						// first point
+						if (selected == points)
+						{
+							sb_last(points).pos = selected->pos;
+						}
+						// last point
+						else if (selected == &sb_last(points))
+						{
+							points->pos = selected->pos;
+						}
+					}
+				}
+				else
+					selectedPath->isClosed = false;
 			}
 			
 			if (ImGui::TreeNode("Danger Zone##Paths"))

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -303,7 +303,7 @@ public:
 	void FlushLines(void)
 	{
 		for (const Line &line : lines)
-			ImGui::GetForegroundDrawList()->AddLine(
+			ImGui::GetBackgroundDrawList()->AddLine(
 				ImVec2(line.x1, line.y1),
 				ImVec2(line.x2, line.y2),
 				line.color,

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1647,6 +1647,19 @@ static const LinkedStringFunc *gSidebarTabs[] = {
 					selectedPath->isClosed = false;
 			}
 			
+			// copy-pasted from InstanceTab()
+			struct Instance *inst = gGui->selectedInstance;
+			ImGui::SeparatorText("Position");
+			int xpos = rintf(inst->pos.x);
+			int ypos = rintf(inst->pos.y);
+			int zpos = rintf(inst->pos.z);
+			int nudgeBy = (ImGui::GetIO().KeyShift) ? 20 : 1; // nudge by 20 if shift is held
+			int nudgeCtrl = nudgeBy; // ctrl has no effect
+			if (ImGui::InputInt("X##WaypointPos", &xpos, nudgeBy, nudgeCtrl)) inst->pos.x = xpos;
+			ImGui::SameLine(); HelpMarker("These buttons nudge farther\n""if you hold the Shift key.");
+			if (ImGui::InputInt("Y##WaypointPos", &ypos, nudgeBy, nudgeCtrl)) inst->pos.y = ypos;
+			if (ImGui::InputInt("Z##WaypointPos", &zpos, nudgeBy, nudgeCtrl)) inst->pos.z = zpos;
+			
 			if (ImGui::TreeNode("Danger Zone##Paths"))
 			{
 				ImGui::TextWrapped(

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1537,16 +1537,18 @@ static const LinkedStringFunc *gSidebarTabs[] = {
 			
 			ImGui::TextWrapped(
 				"Path Editing:\n"
-				"NOTE: A lot of this is still TODO, am brainstorming.\n"
-				" - Paths must always contain at least one point.\n"
-				" - With the first or last point selected, press the"
-				" 'V' key to add a new point.\n"
-				" - You can also add points to the middle of a path"
-				" by right-clicking on the line connecting two points.\n"
-				" - Select a point and press the 'Delete' key to delete it.\n"
+				" - Paths must always contain at least one waypoint.\n"
+				" - With the first or last waypoint selected, press the"
+				" 'V' key to add a new waypoint to the path. Move your"
+				" mouse to position it.\n"
+				" - Hold the Ctrl key while positioning a waypoint to snap"
+				" it to level geometry.\n"
+				" - To reposition an existing waypoint, left-click to select it,"
+				" then press the 'G' key to grab it.\n"
+				" - You can also add waypoints to the middle of a path"
+				" by right-clicking on the line connecting two waypoints.\n"
+				" - Press the 'Delete' key to delete a selected waypoint.\n"
 			);
-			
-			ImGui::TextWrapped("TODO: - List points, can reorder and reverse");
 			
 			if (ImGui::BeginListBox("##PathPointList", ImVec2(-FLT_MIN, 5 * ImGui::GetTextLineHeightWithSpacing())))
 			{

--- a/src/gui.h
+++ b/src/gui.h
@@ -25,6 +25,7 @@ enum RenderGroup
 	RENDERGROUP_IGNORE = 0,
 	RENDERGROUP_ROOM = 0x01000000,
 	RENDERGROUP_INST = 0x02000000,
+	RENDERGROUP_PATHLINE = 0x04000000,
 	RENDERGROUP_MASK_ID = 0x00ffffff,
 	RENDERGROUP_MASK_GROUP = 0xff000000,
 };
@@ -66,6 +67,8 @@ struct GuiInterop
 	Vec3f newSpawnPos; // where a new inst/spawnpoint/etc will instantiate
 	bool rightClickedInViewport;
 	enum RenderGroup rightClickedRenderGroup;
+	int rightClickedLineIndex;
+	int rightClickedLinePathIndex;
 	int selectedRoomIndex;
 	int selectedHeaderIndex;
 	int selectedDayIndex;

--- a/src/misc.c
+++ b/src/misc.c
@@ -1910,9 +1910,10 @@ static void private_SceneParseAddHeader(struct Scene *scene, uint32_t addr)
 					
 					for (int k = 0; k < numPoints; ++k, elem += 6)
 					{
-						Vec3f tmp = { u16r(elem + 0), u16r(elem + 2), u16r(elem + 4) };
-						
-						sb_push(path.points, tmp);
+						sb_push(path.points, ((struct Instance) {
+							.pos = s16r3(elem),
+							INSTANCE_DEFAULT_PATHPOINT
+						}));
 					}
 					
 					sb_push(result->paths, path);

--- a/src/misc.c
+++ b/src/misc.c
@@ -1916,6 +1916,15 @@ static void private_SceneParseAddHeader(struct Scene *scene, uint32_t addr)
 						}));
 					}
 					
+					// first and last points are the same
+					path.isClosed = (numPoints > 3
+						&& !memcmp(&sb_last(path.points).pos
+							, &path.points->pos
+							, sizeof(Vec3f)
+						)
+					);
+						
+					
 					sb_push(result->paths, path);
 				}
 				//sb_udata_segaddr(result->paths) = w1;

--- a/src/misc.h
+++ b/src/misc.h
@@ -521,6 +521,7 @@ struct ActorPath
 	uint8_t additionalPathIndex; // mm only
 	uint16_t customValue; // mm only
 	sb_array(struct Instance, points);
+	bool isClosed;
 };
 
 struct SceneHeader

--- a/src/misc.h
+++ b/src/misc.h
@@ -81,6 +81,14 @@ struct CutsceneOot;
 }
 #define INSTANCE_PREV_INIT INSTANCE_PREV_INIT_UUID(InstanceNewUuid())
 
+#define INSTANCE_DEFAULT_PATHPOINT \
+	.tab = INSTANCE_TAB_PATH, \
+	.mm = { \
+		.halfDayBits = 0xffff, \
+	}, \
+	.prev = INSTANCE_PREV_INIT, \
+
+
 #define for_in(index, count) for (int index = 0; index < count; ++index)
 
 #define CONCAT_(A, B) A##B
@@ -413,6 +421,7 @@ enum InstanceTab
 	INSTANCE_TAB_ACTOR = 0,
 	INSTANCE_TAB_DOOR,
 	INSTANCE_TAB_SPAWN,
+	INSTANCE_TAB_PATH,
 	INSTANCE_TAB_COUNT,
 };
 
@@ -511,7 +520,7 @@ struct ActorPath
 	//uint8_t numPoints; // unused b/c sb_array() has sb_count()
 	uint8_t additionalPathIndex; // mm only
 	uint16_t customValue; // mm only
-	sb_array(Vec3f, points);
+	sb_array(struct Instance, points);
 };
 
 struct SceneHeader

--- a/src/scene-write.c
+++ b/src/scene-write.c
@@ -709,9 +709,9 @@ static uint32_t WorkAppendSceneHeader(struct Scene *scene, struct SceneHeader *h
 			typeof(each->points) points = each->points;
 			WorkblobPush(2);
 			sb_foreach(points, {
-				WorkblobPut16(each->x);
-				WorkblobPut16(each->y);
-				WorkblobPut16(each->z);
+				WorkblobPut16(rintf(each->pos.x));
+				WorkblobPut16(rintf(each->pos.y));
+				WorkblobPut16(rintf(each->pos.z));
 			});
 			WorkblobPut32(WorkblobPop());
 		});

--- a/src/stretchy_buffer.h
+++ b/src/stretchy_buffer.h
@@ -214,6 +214,9 @@
 #define sb_clear  stb_sb_clear
 #define sb_trim   stb_sb_trim
 #define sb_new    stb_sb_new
+#define sb_reverse stb_sb_reverse
+#define sb_reverse_section stb_sb_reverse_section
+#define sb_rotate stb_sb_rotate
 #define sb_swap   stb_sb_swap
 #define sb_swap_safe stb_sb_swap_safe
 #define sb_contains stb_sb_contains
@@ -288,6 +291,39 @@
 	for (int i = index; i < stb__sbn(a) - 1; ++i) \
 		(a)[i] = (a)[i + 1]; \
 	stb__sbn(a)--; \
+}
+
+#define stb_sb_reverse_section(X, START, END) if (stb_sb_count(X) > 1) { \
+	int start = START; \
+	int end = END; \
+	while (start < end) { \
+		typeof(*(X)) tmp = X[start]; \
+		X[start] = X[end]; \
+		X[end] = tmp; \
+		++start; \
+		--end; \
+	} \
+}
+
+#define stb_sb_reverse(X) stb_sb_reverse_section(X, 0, stb_sb_count(X) - 1)
+/*
+#define stb_sb_reverse(X) if (sb_count(X) > 1) { \
+	int num = sb_count(X); \
+	for (int i = 0; i < num / 2; ++i) { \
+		typeof(*(X)) tmp = X[i]; \
+		X[i] = X[(num - 1) - i]; \
+		X[(num - 1) - i] = tmp; \
+	} \
+}
+*/
+
+// moves array left so that index 'D' is moved to beginning
+#define stb_sb_rotate(X, D) if (sb_count(X) > 1) { \
+	int size = sb_count(X); \
+	int nudgeIndex = (D) % size; \
+	sb_reverse_section(X, 0, nudgeIndex - 1); \
+	sb_reverse_section(X, nudgeIndex, size - 1); \
+	sb_reverse(X); \
 }
 
 #define stb__sbraw(a) ((int *) (void *) (a) - SB_HEADER_COUNT)

--- a/src/window.c
+++ b/src/window.c
@@ -1348,6 +1348,15 @@ bool WindowTryInstanceDelete(bool showModal)
 		
 		if (indexOf >= 0)
 		{
+			// don't allow deleting last point of path
+			if (gGui->selectedInstance->tab == INSTANCE_TAB_PATH
+				&& sb_count(*gGui->instanceList) == 1
+			)
+			{
+				GuiPushModal("Can't delete last point of path.");
+				return false;
+			}
+			
 			LogDebug("delete instance %d", indexOf);
 			sb_remove(*gGui->instanceList, indexOf);
 			

--- a/src/window.c
+++ b/src/window.c
@@ -2984,8 +2984,16 @@ void WindowMainLoop(const char *sceneFn)
 			gInput.mouse.isControllingCamera = false;
 
 		if (isRaycasting)
+		{
 			worldRayData.isSelectingInstance = true,
 			worldRayData.renderGroup = RENDERGROUP_INST;
+			
+			// fixes long-standing bug where Ctrl-snapping instance
+			// onto other instance would cause both to be selected
+			// and behave unpredictably
+			if (!GizmoIsIdle(gState.gizmo))
+				worldRayData.isSelectingInstance = false;
+		}
 		
 		// keep
 		if (!gKeepData)

--- a/src/window.c
+++ b/src/window.c
@@ -1242,6 +1242,25 @@ bool WindowDrawLine3D(Vec3f a3D, Vec3f b3D)
 			isHovered = true;
 		}
 		
+		// draw arrow
+		if (true)
+		{
+			Vec2f slope = Vec2f_Normalize(Vec2f_GetLineSlope(start2D, end2D));
+			Vec2f invert = { -slope.y, slope.x };
+			int spread = 15;
+			int length = 15;
+			float thickness = 10;
+			Vec2f base = Vec2f_Add(end2D, Vec2f_MulVal(slope, -length));
+			Vec2f wings[] = {
+				Vec2f_Add(base, Vec2f_MulVal(invert, spread)),
+				Vec2f_Add(base, Vec2f_MulVal(invert, -spread))
+			};
+			for (int i = 0; i < ARRAY_COUNT(wings); ++i)
+				GuiPushLine(UNFOLD_VEC2(wings[i]), UNFOLD_VEC2(end2D), 0x00000080, thickness + 2); // outline
+			for (int i = 0; i < ARRAY_COUNT(wings); ++i)
+				GuiPushLine(UNFOLD_VEC2(wings[i]), UNFOLD_VEC2(end2D), innerColor, thickness);
+		}
+		
 		GuiPushLine(UNFOLD_VEC2(start2D), UNFOLD_VEC2(end2D), 0x00000080, 7.0f); // outline
 		GuiPushLine(UNFOLD_VEC2(start2D), UNFOLD_VEC2(end2D), innerColor, 5.0f);
 	}

--- a/src/window.c
+++ b/src/window.c
@@ -1123,6 +1123,102 @@ Vec2f WindowGetLocalScreenPos(Vec3f point)
 	);
 }
 
+Vec4f WindowGetLocalScreenPos4(Vec3f point)
+{
+	f32 w = gState.winWidth * 0.5f;
+	f32 h = gState.winHeight * 0.5f;
+	Vec4f pos;
+	
+	Matrix_MultVec3fToVec4f_Ext(&point, &pos, &gState.projViewMtx);
+	
+	return Vec4f_New(
+		w + (pos.x / pos.w) * w,
+		h - (pos.y / pos.w) * h,
+		pos.z,
+		pos.w
+	);
+}
+
+Vec2f WindowTryCursorVsLine2D(Vec2f start2D, Vec2f end2D)
+{
+	Vec2f slope = Vec2f_Normalize(Vec2f_GetLineSlope(start2D, end2D));
+	Vec2f invert = { -slope.y, slope.x };
+	int dist = 10;
+	Vec2f mouseStart = {
+		gInput.mouse.pos.x + invert.x * dist,
+		gInput.mouse.pos.y + invert.y * dist
+	};
+	Vec2f mouseEnd = {
+		gInput.mouse.pos.x - invert.x * dist,
+		gInput.mouse.pos.y - invert.y * dist
+	};
+	
+	//GuiPushLine(UNFOLD_VEC2(mouseStart), UNFOLD_VEC2(mouseEnd), -1, 1.0f);
+	
+	return Vec2f_GetLineLineIntersection(
+		start2D,
+		end2D,
+		mouseStart,
+		mouseEnd
+	);
+}
+
+bool WindowDrawLine3D(Vec3f a3D, Vec3f b3D)
+{
+	Vec3f start3D = a3D; // start/end points in 3D space
+	Vec3f end3D = b3D;
+	Vec4f start = WindowGetLocalScreenPos4(a3D); // start/end points in 2D space
+	Vec4f end = WindowGetLocalScreenPos4(b3D);
+	bool isHovered = false;
+	
+	// one or both points not in front of camera
+	if (start.w <= 0 || end.w <= 0)
+	{
+		float step = 1.0 / Vec3f_DistXYZ(a3D, b3D);
+		Vec3f prev = a3D;
+		step *= 10; // 3d worldspace units (1 = precise, 10 = fast)
+		bool unknownEnd = end.w <= 0;
+		for (float amount = 0; amount <= 1; amount += step)
+		{
+			Vec3f next = Vec3f_LERP(a3D, b3D, amount);
+			Vec4f newEnd;
+			Vec4f newStart;
+			// first valid start-point
+			if (start.w <= 0 && (newStart = WindowGetLocalScreenPos4(prev)).w > 0)
+				start = newStart, start3D = prev;
+			// last valid end-point
+			if (unknownEnd && (newEnd = WindowGetLocalScreenPos4(next)).w > 0)
+				end = newEnd, end3D = next;
+			prev = next;
+		}
+	}
+	
+	// both points are in front of the camera
+	if (start.w > 0 && end.w > 0)
+	{
+		Vec2f start2D = { UNFOLD_VEC2(start) };
+		Vec2f end2D = { UNFOLD_VEC2(end) };
+		uint32_t innerColor = 0xffffffff;
+		Vec2f result;
+		
+		// right-click while hovering on a path to subdivide it
+		if (GizmoIsIdle(gState.gizmo) && !isnan((result = WindowTryCursorVsLine2D(start2D, end2D)).x))
+		{
+			innerColor = 0x00ff00ff;
+			worldRayData.renderGroupClicked = RENDERGROUP_PATHLINE;
+			float dist = Vec2f_DistXZ(start2D, result) / Vec2f_DistXZ(start2D, end2D);
+			dist = clamp(dist, 0.10, 0.90); // don't spawn too close to endpoints
+			worldRayData.pos = Vec3f_LERP(start3D, end3D, dist);
+			isHovered = true;
+		}
+		
+		GuiPushLine(UNFOLD_VEC2(start2D), UNFOLD_VEC2(end2D), 0x00000080, 7.0f); // outline
+		GuiPushLine(UNFOLD_VEC2(start2D), UNFOLD_VEC2(end2D), innerColor, 5.0f);
+	}
+	
+	return isHovered;
+}
+
 Vec4f WindowGetLocalScreenVec(Vec3f point)
 {
 	Vec4f pos;
@@ -2846,12 +2942,54 @@ void WindowMainLoop(const char *sceneFn)
 		n64_draw_dlist(matBlank);
 		static GbiGfx gfxGreen[] = { gsDPSetPrimColor(0, 0, 0, 255, 0, 255), gsSPEndDisplayList() };
 		static GbiGfx gfxRed[] = { gsDPSetPrimColor(0, 0, 255, 0, 0, 255), gsSPEndDisplayList() };
+		static GbiGfx gfxCyan[] = { gsDPSetPrimColor(0, 0, 0, 255, 255, 255), gsSPEndDisplayList() };
 		n64_draw_dlist(gfxEnableXray);
 		DrawInstanceList(gGui->actorList);
 		n64_draw_dlist(gfxGreen);
 		DrawInstanceList(gGui->spawnList);
 		n64_draw_dlist(gfxRed);
 		DrawInstanceList(gGui->doorList);
+		// paths
+		n64_draw_dlist(gfxCyan);
+		if (gGui->sceneHeader)
+			sb_foreach(gGui->sceneHeader->paths, {
+				DrawInstanceList(&each->points);
+				// render lines only for selected path
+				if (&each->points == gGui->instanceList) {
+					for (int i = 0; i < sb_count(each->points) - 1; ++i) {
+						Vec3f point = each->points[i].pos;
+						Vec3f next = each->points[i + 1].pos;
+						if (WindowDrawLine3D(point, next)) {
+							gGui->rightClickedLineIndex = i;
+							gGui->rightClickedLinePathIndex = eachIndex;
+							if (gInput.mouse.clicked.right) // hack to keep selection active
+								gGui->selectedInstance = &each->points[i];
+						}
+					}
+					// draw clickable marker at each point
+					if (GizmoIsIdle(gState.gizmo))
+						sb_foreach_named(each->points, point, {
+							Vec4f point2D = WindowGetLocalScreenPos4(point->pos);
+							if (point2D.w > 0) {
+								uint32_t innerColor = 0xffffffff;
+								float cursorDist = Vec2f_DistXZ(
+									(Vec2f) { UNFOLD_VEC2(point2D) },
+									(Vec2f) { UNFOLD_VEC2(gInput.mouse.pos) }
+								);
+								// markers are clickable
+								if (cursorDist < 10) {
+									innerColor = 0x00ff00ff;
+									if (gInput.mouse.clicked.left
+										|| gInput.mouse.clicked.right
+									)
+										gGui->selectedInstance = point;
+								}
+								GuiPushPointX(point2D.x, point2D.y, 0x00000080, 6, 6); // outline
+								GuiPushPointX(point2D.x, point2D.y, innerColor, 2, 5);
+							}
+						})
+				}
+			})
 		n64_draw_dlist(gfxDisableXray);
 		
 		n64_set_tri_callback(0, 0);

--- a/src/window.c
+++ b/src/window.c
@@ -313,6 +313,36 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
 				&& SHORTCUT_CHECKS
 			)
 				WindowTryInstancePaste(true, true);
+			// V
+			else if (!(mods & GLFW_MOD_CONTROL)
+				&& SHORTCUT_CHECKS
+			) {
+				// when path editing, 'V' key adds points
+				if (gGui->selectedInstance
+					&& gGui->selectedInstance->tab == INSTANCE_TAB_PATH
+				) {
+					struct Instance tmp = {
+						.pos = gGui->selectedInstance->pos,
+						INSTANCE_DEFAULT_PATHPOINT
+					};
+					
+					// first point selected in list w/ > 1 points: prepend
+					if (sb_count(*(gGui->instanceList)) > 1
+						&& gGui->selectedInstance == *(gGui->instanceList)
+					) {
+						sb_insert(*(gGui->instanceList), tmp, 0);
+						gGui->selectedInstance = *(gGui->instanceList);
+					}
+					// append
+					else {
+						sb_push(*(gGui->instanceList), tmp);
+						gGui->selectedInstance = &sb_last(*(gGui->instanceList));
+					}
+					
+					GuiPushModal("Inserted path point.");
+					GizmoSetupMove(gState.gizmo);
+				}
+			}
 			break;
 		
 		case GLFW_KEY_X:


### PR DESCRIPTION
Adds actor path previewing and editing to the viewport window and sidebar. Users can:
- View, edit, create, and delete paths.
- Add and remove waypoints.
- Specify which waypoint is a path's starting position.
- Reverse path directions.
- Mark a path as closed so the first and last waypoints stay welded together.